### PR TITLE
Support trail color in exotic theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ With `strokeWidth` param you can customize the `path` circle `strokeWidth`.
 |----------|----------------------------------------------------------------------------------------|---------------|---------|
 | percent     | set the completion percentage                                      | number        | 0    |
 | status   |  set the status of the progress, options: `success`, `error`, `active`           | string        | -       |
-| theme    | set the custom styles of the progress, options: `[status]: { color: [string], symbol: '[any]'}`            | object        | -       |
+| theme    | set the custom styles of the progress, options: `[status]: { color: [string], trailColor: [string], symbol: '[any]'}`            | object        | -       |
 | style       | set the custom style of the react progress bar | object | -       |
 | type       | set the type of the progress bar, options: `circle` | string | -       |
 | width       | set sizes of progress bar type `circle` | number | 132       |
@@ -228,6 +228,8 @@ Future Plans
 - [ ] Add flexibility to custom styles
 
 ### Updates
+
+1.1.1 Trail color can now be specified by a progress theme.
 
 1.1.0 Added `Circle` progress
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ Also you can use the `status` param.
 
 ![Imgur](http://i.imgur.com/ZF95CSp.png)
 
+### Trail color 🤗
+
+```
+<Progress
+  theme={{
+    active: {
+      trailColor:'lightblue',
+      color: 'blue'
+    },
+  }}
+/>
+```
+
+![Imgur](https://i.imgur.com/QUu7ygb.gif)
 
 ### Circle width 😲
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ With `theme` param you can customize icons and styles of the progress bar.
     default: {
       symbol: '😱',
       color: '#fbc630'
-    }
+    },
   }}
 />
 ```
@@ -111,6 +111,37 @@ With `theme` param you can customize icons and styles of the progress bar.
 ![Imgur](http://i.imgur.com/bJmhojg.png)
 ![Imgur](http://i.imgur.com/VK7AoHd.png)
 ![Imgur](http://i.imgur.com/fTcn96g.png)
+
+If you don't specify the theme `trail color`, then the deafult color is used.
+```
+<Progress
+  theme={
+    {
+      error: {
+        symbol: this.state.percent + '%',
+        trailColor: 'pink',
+        color: 'red'
+      },
+      default: {
+        symbol: this.state.percent + '%',
+        trailColor: 'lightblue',
+        color: 'blue'
+      },
+      active: {
+        symbol: this.state.percent + '%',
+        trailColor: 'yellow',
+        color: 'orange'
+      },
+      success: {
+        symbol: this.state.percent + '%',
+        trailColor: 'lime',
+        color: 'green'
+      },
+    }
+  }
+  />
+  ```
+![Imgur](https://i.imgur.com/QUu7ygb.gif)
 
 If you don't pass custom `status` then it will use the default color theme.
 
@@ -145,21 +176,6 @@ Also you can use the `status` param.
 ```
 
 ![Imgur](http://i.imgur.com/ZF95CSp.png)
-
-### Trail color 🤗
-
-```
-<Progress
-  theme={{
-    active: {
-      trailColor:'lightblue',
-      color: 'blue'
-    },
-  }}
-/>
-```
-
-![Imgur](https://i.imgur.com/QUu7ygb.gif)
 
 ### Circle width 😲
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ With `theme` param you can customize icons and styles of the progress bar.
     default: {
       symbol: '😱',
       color: '#fbc630'
-    },
+    }
   }}
 />
 ```
@@ -112,7 +112,7 @@ With `theme` param you can customize icons and styles of the progress bar.
 ![Imgur](http://i.imgur.com/VK7AoHd.png)
 ![Imgur](http://i.imgur.com/fTcn96g.png)
 
-If you don't specify the theme `trail color`, then the deafult color is used.
+If you don't specify the theme `trail color`, then the deafult value of `#efefef` will be used.
 ```
 <Progress
   theme={
@@ -136,11 +136,11 @@ If you don't specify the theme `trail color`, then the deafult color is used.
         symbol: this.state.percent + '%',
         trailColor: 'lime',
         color: 'green'
-      },
+      }
     }
   }
-  />
-  ```
+/>
+```
 ![Imgur](https://i.imgur.com/QUu7ygb.gif)
 
 If you don't pass custom `status` then it will use the default color theme.

--- a/src/Circle.js
+++ b/src/Circle.js
@@ -55,7 +55,7 @@ export default class Circle extends Component {
       >
         <path
           d={pathString}
-          stroke={trailColor || "#efefef"}
+          stroke={trailColor}
           strokeWidth={strokeWidth}
           fillOpacity="0"
           style={trailPathStyle}

--- a/src/Circle.js
+++ b/src/Circle.js
@@ -55,7 +55,7 @@ export default class Circle extends Component {
       >
         <path
           d={pathString}
-          stroke="#efefef"
+          stroke={trailColor || "#efefef"}
           strokeWidth={strokeWidth}
           fillOpacity="0"
           style={trailPathStyle}

--- a/src/Line.js
+++ b/src/Line.js
@@ -3,19 +3,22 @@ import cx from 'classnames';
 import { STATUSES } from './constants';
 import s from './style/line.scss';
 
-function Line({ prefixClass, percent, className, status, background }) {
+function Line({ prefixClass, percent, className, status, background, trailColor }) {
   const classes = cx(s[`${prefixClass}-line`], className);
   const innerClasses = cx(s[`${prefixClass}-line-inner`], {
     [s[`${prefixClass}-line-inner-status-${status}`]]: !!status
   });
-  const style = {
+  const progressStyle = {
     width: `${percent}%`,
     backgroundColor: background
   };
+  const trailStyle = {
+    backgroundColor: trailColor
+  };
 
   return (
-    <div className={classes}>
-      <div className={innerClasses} style={style}></div>
+    <div className={classes} style={trailStyle}>
+      <div className={innerClasses} style={progressStyle}></div>
     </div>
   );
 }
@@ -26,7 +29,8 @@ Line.propTypes = {
   className: PropTypes.className,
   status: PropTypes.oneOf([STATUSES.ACTIVE, STATUSES.SUCCESS,
     STATUSES.DEFAULT, STATUSES.ERROR]),
-  background: PropTypes.string
+  background: PropTypes.string,
+  trailColor: PropTypes.string,
 };
 
 export default Line;

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import cx from 'classnames';
-import { prefixClass, STATUSES, COLOR_MAP } from './constants';
+import { prefixClass, STATUSES, COLOR_MAP, DEFAULT_TRAIL_COLOR } from './constants';
 import s from './style/progress.scss';
 import Line from './Line';
 import Circle from './Circle';
@@ -58,6 +58,7 @@ export default class Progress extends Component {
 
     const themeProgress = theme && theme[progressStatus];
     const progressColor = themeProgress ? themeProgress.color : COLOR_MAP[progressStatus];
+    const trailColor = themeProgress ? themeProgress.trailColor : DEFAULT_TRAIL_COLOR;
 
     if (type === 'circle') {
       const circleSize = width || 132;
@@ -81,6 +82,7 @@ export default class Progress extends Component {
             percent={percent}
             strokeWidth={circleWidth}
             strokeColor={progressColor}
+            trailColor={trailColor}
             prefixClass={prefixClass}
             gapDegree={gapDeg}
             gapPosition={gapPos}
@@ -100,6 +102,7 @@ export default class Progress extends Component {
           percent={percent}
           status={progressStatus}
           background={progressColor}
+          trailColor={trailColor}
         />
         <div className={cx(s[`${prefixClass}-symbol`], symbolClassName)}>{symbol}</div>
       </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 export const prefixClass = 'react-sweet-progress';
+export const DEFAULT_TRAIL_COLOR = '#efefef';
 export const STATUSES = {
   ACTIVE: 'active',
   SUCCESS: 'success',


### PR DESCRIPTION
Allow for progress trail color to be changed using the exotic theme.
This works for both the `circle` and the `line` progress components.